### PR TITLE
Update Lock/Unlock Services

### DIFF
--- a/car.yaml
+++ b/car.yaml
@@ -52,9 +52,10 @@
                       action: call-service
                       confirmation:
                         text: Lock Doors?
-                      service: subaru.lock
-                      service_data:
-                        vin: <YOUR_VIN_HERE>
+                      service: lock.lock
+                      service_data: {}
+                      target:
+                        entity_id: <YOUR VEHICLE ENTITY>
                     type: button
                   - entity: ''
                     icon: 'mdi:lock-open-variant'
@@ -67,9 +68,10 @@
                       action: call-service
                       confirmation:
                         text: Unlock Doors?
-                      service: subaru.unlock
-                      service_data:
-                        vin: <YOUR_VIN_HERE>
+                      service: lock.unlock
+                      service_data: {}
+                      target:
+                        entity_id: <YOUR VEHICLE ENTITY>
                     type: button
                 type: horizontal-stack
               - cards:


### PR DESCRIPTION
v0.50.0 of the underlying custom component deprecated the custom subaru.lock and subaru.unlock service calls - it now uses the built in lock.lock and lock.unlock services, with a reference to the entity instead of the VIN

Link to v0.50.0 Release Notes: https://github.com/G-Two/homeassistant-subaru/releases/tag/v0.5.0